### PR TITLE
fix: 横幅1440px固定と横スクロール防止、ヒーローテキスト中央寄せ

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,7 +14,7 @@
   }
 
   body {
-    @apply bg-[#E5E7EB] text-gray-900;
+    @apply bg-[#F3F4F6] text-gray-900;
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,8 +13,13 @@
     @apply border-gray-light/20;
   }
 
+  html,
   body {
-    @apply bg-[#F3F4F6] text-gray-900 overflow-x-hidden;
+    min-width: 1440px;
+  }
+
+  body {
+    @apply bg-[#F3F4F6] text-gray-900 overflow-x-auto;
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,11 +15,13 @@
 
   html,
   body {
-    min-width: 1440px;
+    width: 1440px;
+    margin: 0 auto;
+    overflow-x: hidden;
   }
 
   body {
-    @apply bg-[#F3F4F6] text-gray-900 overflow-x-auto;
+    @apply bg-[#F3F4F6] text-gray-900;
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,7 +14,7 @@
   }
 
   body {
-    @apply bg-[#F3F4F6] text-gray-900;
+    @apply bg-[#F3F4F6] text-gray-900 overflow-x-hidden;
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,7 +35,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja" className="scroll-smooth">
-      <body className={`${inter.variable} ${geistMono.variable} antialiased`}>
+      <body
+        className={`${inter.variable} ${geistMono.variable} antialiased w-[1440px] mx-auto`}
+      >
         <Header />
         {children}
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from 'next';
-import { Geist, Geist_Mono } from 'next/font/google';
+import { Geist_Mono, Inter } from 'next/font/google';
 import { Header } from '@/components/Header';
 import './globals.css';
 
-const geistSans = Geist({
-  variable: '--font-geist-sans',
+const inter = Inter({
+  variable: '--font-inter',
+  weight: ['400', '700', '900'],
   subsets: ['latin'],
 });
 
@@ -35,7 +36,7 @@ export default function RootLayout({
   return (
     <html lang="ja" className="scroll-smooth">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${inter.variable} ${geistMono.variable} antialiased`}
       >
         <Header />
         {children}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,9 +35,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja" className="scroll-smooth">
-      <body
-        className={`${inter.variable} ${geistMono.variable} antialiased w-[1440px] mx-auto`}
-      >
+      <body className={`${inter.variable} ${geistMono.variable} antialiased`}>
         <Header />
         {children}
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,9 +35,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja" className="scroll-smooth">
-      <body
-        className={`${inter.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={`${inter.variable} ${geistMono.variable} antialiased`}>
         <Header />
         {children}
       </body>

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -17,7 +17,7 @@ export function Hero() {
             className="mb-6"
           >
             <h1 className="font-black leading-tight tracking-tight">
-              <span className="block text-[110px] text-gray-900">
+              <span className="block whitespace-nowrap text-[110px] text-gray-900">
                 Go Beyond Boundaries
               </span>
               <motion.span

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -6,22 +6,91 @@ import { motion } from 'framer-motion';
 
 export function Hero() {
   return (
-    <Section id="hero" className="min-h-screen flex items-center">
+    <Section id="hero" className="min-h-[calc(100vh-90px)] flex items-center">
       <Container>
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-        >
-          <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold mb-6">
-            Hero Section
-          </h1>
-          <p className="text-lg md:text-xl text-gray-light/80 max-w-2xl">
-            ヒーローセクションのコンテンツがここに入ります。
-          </p>
-        </motion.div>
+        <div className="max-w-5xl mx-auto text-center">
+          {/* メイン見出し */}
+          <motion.div
+            initial={{ opacity: 0, y: 30 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8, ease: 'easeOut' }}
+            className="mb-8"
+          >
+            <h1 className="text-5xl md:text-6xl lg:text-7xl xl:text-8xl font-bold leading-tight">
+              <span className="block text-gray-900">Go Beyond</span>
+              <span className="block text-gray-900">Boundaries</span>
+              <motion.span
+                initial={{ opacity: 0, x: -20 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: 0.8, delay: 0.3, ease: 'easeOut' }}
+                className="block text-brand"
+              >
+                Make it run
+              </motion.span>
+            </h1>
+          </motion.div>
+
+          {/* サブテキスト */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8, delay: 0.5, ease: 'easeOut' }}
+            className="max-w-2xl mx-auto"
+          >
+            <p className="text-lg md:text-xl lg:text-2xl text-gray-600 leading-relaxed">
+              私たちは、限界を超えた革新的なソリューションで、
+              <br className="hidden md:block" />
+              あなたのビジネスを次のステージへと導きます。
+            </p>
+          </motion.div>
+
+          {/* CTAボタン */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8, delay: 0.7, ease: 'easeOut' }}
+            className="mt-12"
+          >
+            <motion.button
+              className="inline-flex items-center gap-3 bg-brand text-white px-8 py-4 rounded-full font-bold text-lg hover:bg-brand/90 transition-colors focus:outline-none focus:ring-2 focus:ring-brand focus:ring-offset-2"
+              whileHover={{ scale: 1.05 }}
+              whileTap={{ scale: 0.95 }}
+              aria-label="お問い合わせ"
+            >
+              お問い合わせ
+            </motion.button>
+          </motion.div>
+
+          {/* スクロールインジケーター */}
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 1, delay: 1.2 }}
+            className="mt-20"
+            aria-hidden="true"
+          >
+            <motion.div
+              animate={{ y: [0, 10, 0] }}
+              transition={{ duration: 1.5, repeat: Infinity, ease: 'easeInOut' }}
+              className="inline-block"
+            >
+              <svg
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="text-gray-400"
+              >
+                <path d="M12 5v14M19 12l-7 7-7-7" />
+              </svg>
+            </motion.div>
+          </motion.div>
+        </div>
       </Container>
     </Section>
   );
 }
-

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -8,22 +8,23 @@ export function Hero() {
   return (
     <Section id="hero" className="min-h-[calc(100vh-90px)] flex items-center">
       <Container>
-        <div className="max-w-5xl mx-auto text-center">
+        <div className="max-w-6xl mx-auto text-center">
           {/* メイン見出し */}
           <motion.div
             initial={{ opacity: 0, y: 30 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8, ease: 'easeOut' }}
-            className="mb-8"
+            className="mb-6"
           >
-            <h1 className="text-5xl md:text-6xl lg:text-7xl xl:text-8xl font-bold leading-tight">
-              <span className="block text-gray-900">Go Beyond</span>
-              <span className="block text-gray-900">Boundaries</span>
+            <h1 className="font-black leading-tight tracking-tight">
+              <span className="block text-[110px] text-gray-900">
+                Go Beyond Boundaries
+              </span>
               <motion.span
                 initial={{ opacity: 0, x: -20 }}
                 animate={{ opacity: 1, x: 0 }}
                 transition={{ duration: 0.8, delay: 0.3, ease: 'easeOut' }}
-                className="block text-brand"
+                className="block text-[110px] text-brand"
               >
                 Make it run
               </motion.span>
@@ -35,59 +36,11 @@ export function Hero() {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8, delay: 0.5, ease: 'easeOut' }}
-            className="max-w-2xl mx-auto"
+            className="mt-8"
           >
-            <p className="text-lg md:text-xl lg:text-2xl text-gray-600 leading-relaxed">
-              私たちは、限界を超えた革新的なソリューションで、
-              <br className="hidden md:block" />
-              あなたのビジネスを次のステージへと導きます。
+            <p className="text-xl text-gray-600">
+              境界を超え、テクノロジーで世界を回す。
             </p>
-          </motion.div>
-
-          {/* CTAボタン */}
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8, delay: 0.7, ease: 'easeOut' }}
-            className="mt-12"
-          >
-            <motion.button
-              className="inline-flex items-center gap-3 bg-brand text-white px-8 py-4 rounded-full font-bold text-lg hover:bg-brand/90 transition-colors focus:outline-none focus:ring-2 focus:ring-brand focus:ring-offset-2"
-              whileHover={{ scale: 1.05 }}
-              whileTap={{ scale: 0.95 }}
-              aria-label="お問い合わせ"
-            >
-              お問い合わせ
-            </motion.button>
-          </motion.div>
-
-          {/* スクロールインジケーター */}
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 1, delay: 1.2 }}
-            className="mt-20"
-            aria-hidden="true"
-          >
-            <motion.div
-              animate={{ y: [0, 10, 0] }}
-              transition={{ duration: 1.5, repeat: Infinity, ease: 'easeInOut' }}
-              className="inline-block"
-            >
-              <svg
-                width="24"
-                height="24"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="text-gray-400"
-              >
-                <path d="M12 5v14M19 12l-7 7-7-7" />
-              </svg>
-            </motion.div>
           </motion.div>
         </div>
       </Container>

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -16,15 +16,15 @@ export function Hero() {
             transition={{ duration: 0.8, ease: 'easeOut' }}
             className="mb-6"
           >
-            <h1 className="font-black leading-tight tracking-tight">
-              <span className="block whitespace-nowrap text-[110px] text-gray-900">
+            <h1 className="font-black leading-tight tracking-tight text-center">
+              <span className="block text-[90px] text-gray-900">
                 Go Beyond Boundaries
               </span>
               <motion.span
                 initial={{ opacity: 0, x: -20 }}
                 animate={{ opacity: 1, x: 0 }}
                 transition={{ duration: 0.8, delay: 0.3, ease: 'easeOut' }}
-                className="block text-[110px] text-brand"
+                className="block text-[90px] text-brand"
               >
                 Make it run
               </motion.span>

--- a/src/components/ui/Container.tsx
+++ b/src/components/ui/Container.tsx
@@ -8,7 +8,7 @@ interface ContainerProps {
 
 export function Container({ children, className }: ContainerProps) {
   return (
-    <div className={cn('mx-auto max-w-7xl px-4 sm:px-6 lg:px-8', className)}>
+    <div className={cn('mx-auto w-full px-4 sm:px-6 lg:px-8', className)}>
       {children}
     </div>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,7 +14,7 @@ const config: Config = {
         'gray-light': '#F3F4F6',
       },
       fontFamily: {
-        sans: ['var(--font-geist-sans)', 'system-ui', 'sans-serif'],
+        sans: ['var(--font-inter)', 'Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
         mono: ['var(--font-geist-mono)', 'monospace'],
       },
     },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,7 +14,13 @@ const config: Config = {
         'gray-light': '#F3F4F6',
       },
       fontFamily: {
-        sans: ['var(--font-inter)', 'Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        sans: [
+          'var(--font-inter)',
+          'Inter',
+          'ui-sans-serif',
+          'system-ui',
+          'sans-serif',
+        ],
         mono: ['var(--font-geist-mono)', 'monospace'],
       },
     },
@@ -23,4 +29,3 @@ const config: Config = {
 };
 
 export default config;
-


### PR DESCRIPTION
## 概要
Issue #1 の要件に基づき、横幅1440px固定と横スクロール防止、ヒーローセクションのテキスト中央寄せを実装しました。

## 変更内容

### 1. 横幅1440px固定 + 横スクロール防止
- `globals.css`: html/bodyに`width: 1440px`と`overflow-x: hidden`を設定
- `layout.tsx`: bodyから`w-[1440px] mx-auto`を削除（CSSで制御）
- `Container.tsx`: `max-w-7xl`を`w-full`に変更（親の幅に従う）

### 2. ヒーローセクションのテキスト中央寄せ
- `Hero.tsx`: 
  - フォントサイズを110px→90pxに縮小（1440px幅に収まるように）
  - `whitespace-nowrap`を削除（テキストが折り返し可能に）
  - h1に`text-center`を明示的に追加

## 検証結果（Playwright MCP）
- ✅ 横スクロールバーが表示されない（`hasScrollbar: false`）
- ✅ bodyとhtmlの幅が1440pxに固定
- ✅ ヒーローセクションのテキストが中央寄せ
- ✅ コンテンツが1440px幅に収まっている

## スクリーンショット
修正後のヒーローセクション：
- テキストが中央寄せ
- 横スクロールなし
- 1440px固定幅で表示

Closes #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated the default font to Inter
  * Fixed page width to 1440px for consistent display

* **New Features**
  * Enhanced hero section with centered layout
  * Added animated entrance effects with staggered timing on hero content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->